### PR TITLE
feat: Randomize set selection in THRESHOLD_SUSTAINED

### DIFF
--- a/lib/data/mainSets/THRESHOLD_SUSTAINED.js
+++ b/lib/data/mainSets/THRESHOLD_SUSTAINED.js
@@ -4,6 +4,9 @@ export const THRESHOLD_SUSTAINED = (energySystem, cssSecondsPer100, remainingDis
     // New pace: At CSS
     let targetPacePer100 = cssSecondsPer100;
 
+    console.log('--- THRESHOLD_SUSTAINED ---');
+    console.log('remainingDistanceForMainSet:', remainingDistanceForMainSet);
+
     const en2SetPatterns = [
         // Ordered by a rough preference or commonality, can be adjusted
         { id: '18x100', reps: 18, dist: 100, rest: 'r10"', requiredDist: 18 * 100, paceDesc: 'CSS' },
@@ -16,48 +19,71 @@ export const THRESHOLD_SUSTAINED = (energySystem, cssSecondsPer100, remainingDis
         { id: 'Nx800', baseDist: 800, rest: 'r90"', maxReps: 8, paceDesc: 'CSS' }, 
         { id: 'Nx1000', baseDist: 1000, rest: 'r90"', maxReps: 6, paceDesc: 'CSS' } 
     ];
+    console.log('en2SetPatterns:', JSON.stringify(en2SetPatterns.map(p => p.id)));
 
-    let bestFitSet = null;
-    let maxAchievedDistance = 0;
+    let viablePatterns = [];
 
     for (const pattern of en2SetPatterns) {
-        if (pattern.baseDist) { // For NxDist patterns (800, 1000)
+        if (pattern.baseDist) { // For NxDist patterns
             if (remainingDistanceForMainSet >= pattern.baseDist) {
                 let numReps = Math.floor(remainingDistanceForMainSet / pattern.baseDist);
                 numReps = Math.min(numReps, pattern.maxReps);
                 if (numReps > 0) {
                     const currentSetTotalDist = numReps * pattern.baseDist;
-                    if (currentSetTotalDist > maxAchievedDistance) {
-                        maxAchievedDistance = currentSetTotalDist;
-                        bestFitSet = {
-                            reps: numReps,
-                            dist: pattern.baseDist,
-                            rest: pattern.rest,
-                            totalDist: currentSetTotalDist,
-                            paceDesc: pattern.paceDesc,
-                            id: `${numReps}x${pattern.baseDist}`
-                        };
-                    }
+                    viablePatterns.push({
+                        reps: numReps,
+                        dist: pattern.baseDist,
+                        rest: pattern.rest,
+                        totalDist: currentSetTotalDist,
+                        paceDesc: pattern.paceDesc,
+                        id: `${numReps}x${pattern.baseDist}`
+                    });
                 }
             }
         } else { // For fixed rep x dist patterns
             if (remainingDistanceForMainSet >= pattern.requiredDist) {
-                // If it fits, it's a candidate. Prefer sets that use more of the available distance.
-                if (pattern.requiredDist > maxAchievedDistance) {
-                    maxAchievedDistance = pattern.requiredDist;
-                    bestFitSet = {
-                        reps: pattern.reps,
-                        dist: pattern.dist,
-                        rest: pattern.rest,
-                        totalDist: pattern.requiredDist,
-                        paceDesc: pattern.paceDesc,
-                        id: pattern.id
-                    };
-                }
+                viablePatterns.push({
+                    reps: pattern.reps,
+                    dist: pattern.dist,
+                    rest: pattern.rest,
+                    totalDist: pattern.requiredDist,
+                    paceDesc: pattern.paceDesc,
+                    id: pattern.id
+                });
             }
         }
     }
+    console.log('Viable patterns after filtering:', JSON.stringify(viablePatterns.map(p => p.id)));
 
+    let bestFitSet = null;
+    let selectionMethod = '';
+
+    if (viablePatterns.length > 0) {
+        if (viablePatterns.length === 1) {
+            bestFitSet = viablePatterns[0];
+            selectionMethod = 'Single viable pattern';
+        } else {
+            // Prioritize patterns that use more of the available distance
+            let maxDistance = 0;
+            viablePatterns.forEach(pattern => {
+                if (pattern.totalDist > maxDistance) {
+                    maxDistance = pattern.totalDist;
+                }
+            });
+            const bestDistancePatterns = viablePatterns.filter(p => p.totalDist === maxDistance);
+
+            if (bestDistancePatterns.length === 1) {
+                bestFitSet = bestDistancePatterns[0];
+                selectionMethod = 'Single best distance pattern';
+            } else {
+                // If multiple patterns achieve the same max distance, pick one randomly
+                const randomIndex = Math.floor(Math.random() * bestDistancePatterns.length);
+                bestFitSet = bestDistancePatterns[randomIndex];
+                selectionMethod = `Randomly selected from ${bestDistancePatterns.length} best distance patterns`;
+            }
+        }
+    } else {
+        selectionMethod = 'Fallback logic initiated';
     // Fallback: if no specific pattern fits, try to construct a simpler set.
     // E.g., if remaining is 1200, 18x100 (1800) is too much.
     // Perhaps multiple shorter sets or a smaller version of one.
@@ -71,10 +97,12 @@ export const THRESHOLD_SUSTAINED = (energySystem, cssSecondsPer100, remainingDis
             fallbackDist = 200;
             fallbackReps = Math.min(Math.floor(remainingDistanceForMainSet / 200), 40); 
             fallbackRest = 'r20"';
+            selectionMethod += ' -> Attempting fallback with 200s';
         } else { // Must be 100s
             fallbackDist = 100;
             fallbackReps = Math.min(Math.floor(remainingDistanceForMainSet / 100), 60); 
             fallbackRest = 'r10"';
+            selectionMethod += ' -> Attempting fallback with 100s';
         }
         if (fallbackReps > 0) {
             fallbackTotal = fallbackReps * fallbackDist;
@@ -87,10 +115,26 @@ export const THRESHOLD_SUSTAINED = (energySystem, cssSecondsPer100, remainingDis
                     paceDesc: 'CSS',
                     id: `${fallbackReps}x${fallbackDist} (fallback)`
                 };
+                selectionMethod += ` -> Selected fallback: ${bestFitSet.id}`;
+            } else {
+                selectionMethod += ' -> Fallback resulted in no meaningful set (totalDist <=0)';
             }
+        } else {
+            selectionMethod += ' -> Fallback resulted in no meaningful set (fallbackReps <=0)';
+        }
+    } else {
+        if (bestFitSet) { // This case should ideally not be reached if !bestFitSet is the entry condition
+             selectionMethod += ' -> Fallback logic skipped (bestFitSet already found, unexpected)';
+        } else if (remainingDistanceForMainSet < 100) {
+            selectionMethod += ' -> Fallback logic skipped (remainingDistance < 100)';
+        } else {
+            selectionMethod += ' -> Fallback logic skipped (conditions not met, this is unexpected if viablePatterns was empty)';
         }
     }
+}
 
+    console.log('Pattern selection method:', selectionMethod);
+    console.log('Final bestFitSet:', bestFitSet ? JSON.stringify(bestFitSet) : 'null');
 
     let descriptiveMessage;
 
@@ -106,6 +150,8 @@ export const THRESHOLD_SUSTAINED = (energySystem, cssSecondsPer100, remainingDis
             descriptiveMessage = `EN2: Could not fit standard EN2 set for ${energySystem}. Available: ${remainingDistanceForMainSet}.`;
         }
     }
+    console.log('Descriptive message:', descriptiveMessage);
+    console.log('--- END THRESHOLD_SUSTAINED ---');
 
     return { sets, mainSetTotalDist, targetPacePer100, descriptiveMessage };
 };


### PR DESCRIPTION
I modified THRESHOLD_SUSTAINED.js to introduce an element of randomness in the selection of swim sets.

Previously, the code would iterate through a predefined list of set patterns and deterministically pick the best fit.

With this change:
- I still identify all patterns that fit the `remainingDistanceForMainSet`.
- If multiple patterns are viable and offer the same maximum total distance, I now choose one at random from this subset of equally good options.
- If only one pattern is the best fit, or if patterns offer different total distances, the selection process prioritizes maximizing the workout distance as before.
- Fallback logic remains unchanged.

This change makes the main set generation for THRESHOLD_SUSTAINED less predictable while ensuring the chosen set is still appropriate for the available distance and training goals.